### PR TITLE
Define 2 environments for parallel travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,10 @@ addons:
       # this installs an older version of cabal which doesn't support new-build
       #- cabal-install
 
+env:
+- BUILD=stack
+- BUILD=cabal
+
 before_install:
 # Download and unpack the stack executable
 - mkdir -p ~/.local/bin
@@ -39,13 +43,13 @@ before_install:
 
 install:
 # Build dependencies (stack)
-- stack --no-terminal --install-ghc test --only-dependencies
+- if [ "$BUILD" == "stack" ]; then stack --no-terminal --install-ghc test --only-dependencies ;fi
 # Build dependencies (cabal)
-- ~/.local/bin/cabal update
-- ~/.local/bin/cabal new-build --only-dependencies
+- if [ "$BUILD" == "cabal" ]; then ~/.local/bin/cabal update ;fi
+- if [ "$BUILD" == "cabal" ]; then ~/.local/bin/cabal new-build --only-dependencies ;fi
 
 script:
 # Build the package, its tests, and its docs and run the tests (stack)
-- stack --no-terminal test --haddock --no-haddock-deps
+- if [ "$BUILD" == "stack" ]; then stack --no-terminal test --haddock --no-haddock-deps ;fi
 # Build the package (cabal)
-- ~/.local/bin/cabal new-build
+- if [ "$BUILD" == "cabal" ]; then ~/.local/bin/cabal new-build ;fi


### PR DESCRIPTION
Using two simple environment variables settings, travis will run
both "envs" in parallel. The scripts then just have to check for
configured environment variables to be set. All scripts defined in
`install` and `script` will still run, but they'll check for the
environment variables to be set before running them.

closes https://github.com/gelisam/hawk/issues/182
closes #182